### PR TITLE
Resolve #296 return receivingId to sender in test env

### DIFF
--- a/lambda/src/dynamoDBTxOps.js
+++ b/lambda/src/dynamoDBTxOps.js
@@ -176,6 +176,11 @@ function formatQueriedTransfer (
     item.receivingId = item.receivingId
     // mask out transferId for receiver
     item.transferId = ''
+  } else if (deploymentStage === 'prod' || deploymentStage === 'staging') {
+    // Only mask out receivingId in prod or staging env
+    item.transferId = item.transferId
+    // mask out receivingId for sender
+    item.receivingId = ''
   }
   return item
 }


### PR DESCRIPTION
- Previously getTransfer did not mask out receiving ID for sender in all
environments. Now it masks out receiving for sender in prod and staging